### PR TITLE
Run faster when NDK is already installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ The location to the Android NDK tools package to be installed.
 The location on disk where you'd like to NDK to be installed.
 
     android_ndk_dependency_packages:
-  		- "libncurses5:i386"
-		- "libstdc++6:i386"
-		- "zlib1g:i386"
+  		- "libncurses5"
+		- "libstdc++6"
+		- "zlib1g"
 		- "imagemagick"
 		- "expect"
 		- "gradle"
@@ -31,7 +31,6 @@ The location on disk where you'd like to NDK to be installed.
 		- "ccache"
 		- "autoconf"
 		- "automake"
-		- "ant"
 		- "ccache"
 		- "python-dev"
 		- "zlibc"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,9 @@ android_ndk_version: "10d"
 android_ndk_install_location: /opt/android/ndk
 
 android_ndk_dependency_packages:
-  - "libncurses5:i386"
-  - "libstdc++6:i386"
-  - "zlib1g:i386"
+  - "libncurses5"
+  - "libstdc++6"
+  - "zlib1g"
   - "imagemagick"
   - "expect"
   - "gradle"
@@ -15,7 +15,11 @@ android_ndk_dependency_packages:
   - "ccache"
   - "autoconf"
   - "automake"
-  - "ant"
   - "ccache"
   - "python-dev"
   - "zlibc"
+ubuntu_1204_ia32_libs:
+  - "libgd2-xpm"
+  - "libgphoto2-2"
+  - "libsane"
+  - "ia32-libs-multiarch"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,10 @@
 ---
 # defaults file for android-sdk
 
-android_ndk_version: "10d"
+android_ndk_version: "10e"
+# md5sums come from http://developer.android.com/ndk/downloads/index.html
+android_ndk_md5sum_32bit: "c3edd3273029da1cbd2f62c48249e978"
+ansible_ndk_md5sum_64bit: "19af543b068bdb7f27787c2bc69aba7f"
 android_ndk_install_location: /opt/android/ndk
 
 android_ndk_dependency_packages:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,5 +12,3 @@ galaxy_info:
   categories:
   - development
   - system
-dependencies:
-    - { role: "nickp666.android-sdk" }

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -4,15 +4,10 @@
   when: ansible_distribution_version == "14.04"
 
 - name: Install ia32-libs on 12.04
-  apt: pkg={{ item }} state=latest
+  apt: pkg={{ item }} state=latest update_cache=yes
   when: ansible_distribution_version == "12.04"
-  with_items:
-    - libgd2-xpm:i386
-    - libgphoto2-2:i386
-    - libsane:i386
-    - ia32-libs-multiarch
-    - ia32-libs
+  with_items: ubuntu_1204_ia32_libs
 
 - name: Install build dependencies
-  apt: pkg={{ item }} state=latest
+  apt: pkg={{ item }} state=latest update_cache=yes
   with_items: android_ndk_dependency_packages

--- a/tasks/ndktools.yml
+++ b/tasks/ndktools.yml
@@ -1,4 +1,8 @@
 ---
+- name: See if we already have the NDK
+  # Check for a file that's created at the end of successful install
+  stat: path="/etc/profile.d/Z99-android-ndk.sh"  
+  register: ndk_installed_PATH
 
 - name: Ensure Android NDK tools directory exists
   file: path={{ android_ndk_install_location }} state=directory
@@ -8,18 +12,20 @@
     url="http://dl.google.com/android/ndk/android-ndk-r{{ android_ndk_version }}-linux-x86_64.bin" 
     dest="{{ android_ndk_install_location }}/ndk.bin"
     #checksum="md5:{{ android_ndk_md5sum_64bit }}"
-  when: ansible_userspace_bits == "64"
+  when: ansible_userspace_bits == "64" and 
+        ndk_installed_PATH.stat.exists == False
 
 - name: Download Android NDK tools, x86
   get_url: 
     url="http://dl.google.com/android/ndk/android-ndk-r{{ android_ndk_version }}-linux-x86.bin" 
     dest="{{ android_ndk_install_location }}/ndk.bin"
     #checksum="md5:{{ android_ndk_md5sum_32bit }}"
-  when: ansible_userspace_bits == "32"
-
+  when: ansible_userspace_bits == "32" and 
+        ndk_installed_PATH.stat.exists == False
 
 - name: Change ndk.bin permissions
   file: path="{{ android_ndk_install_location }}/ndk.bin" mode="0755"
+  when: ndk_installed_PATH.stat.exists == False
 
 - name: Execute NDK installer
   command: "{{ android_ndk_install_location }}/ndk.bin"
@@ -27,6 +33,7 @@
       chdir: "{{ android_ndk_install_location }}"
       # Test whether installation has succeeded before on this host
       creates: /etc/profile.d/Z99-android-ndk.sh
+  when: ndk_installed_PATH.stat.exists == False
 
 - name: Remove alias
   file: path="{{ android_ndk_install_location }}/android-ndk-linux" state="absent"

--- a/tasks/ndktools.yml
+++ b/tasks/ndktools.yml
@@ -3,8 +3,20 @@
 - name: Ensure Android NDK tools directory exists
   file: path={{ android_ndk_install_location }} state=directory
 
-- name: Download Android NDK tools
-  get_url: url="http://dl.google.com/android/ndk/android-ndk-r{{ android_ndk_version }}-linux-x86_64.bin" dest="{{ android_ndk_install_location }}/ndk.bin"
+- name: Download Android NDK tools, x86_64
+  get_url: 
+    url="http://dl.google.com/android/ndk/android-ndk-r{{ android_ndk_version }}-linux-x86_64.bin" 
+    dest="{{ android_ndk_install_location }}/ndk.bin"
+    #checksum="md5:{{ android_ndk_md5sum_64bit }}"
+  when: ansible_userspace_bits == "64"
+
+- name: Download Android NDK tools, x86
+  get_url: 
+    url="http://dl.google.com/android/ndk/android-ndk-r{{ android_ndk_version }}-linux-x86.bin" 
+    dest="{{ android_ndk_install_location }}/ndk.bin"
+    #checksum="md5:{{ android_ndk_md5sum_32bit }}"
+  when: ansible_userspace_bits == "32"
+
 
 - name: Change ndk.bin permissions
   file: path="{{ android_ndk_install_location }}/ndk.bin" mode="0755"

--- a/tasks/ndktools.yml
+++ b/tasks/ndktools.yml
@@ -25,6 +25,8 @@
   command: "{{ android_ndk_install_location }}/ndk.bin"
   args:
       chdir: "{{ android_ndk_install_location }}"
+      # Test whether installation has succeeded before on this host
+      creates: /etc/profile.d/Z99-android-ndk.sh
 
 - name: Remove alias
   file: path="{{ android_ndk_install_location }}/android-ndk-linux" state="absent"


### PR DESCRIPTION
This depends on some commits from https://github.com/elleryq/galaxy-role-android-ndk/pull/1 . 

I'm working on a role which depends on the NDK, and the NDK role was doing some very slow operations (re-downloading the NDK, for instance) when they weren't needed. These changes follow the advice in https://raymii.org/s/tutorials/Ansible_-_Only_if_a_file_exists_or_does_not_exist.html to skip the NDK installation's slower operations when it looks like it's already installed. 

It could behave unexpectedly on hosts that've already had the NDK installed to the PATH from some other source, so if predictability in odd edge cases is more important to you than a faster Ansible run time when testing, don't merge this. 
