### PR TITLE
Fail gracefully on non-Debian hosts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
 # tasks file for android-ndk
 - include: dependencies.yml
+  when: ansible_os_family == "Debian"
+
 - include: ndktools.yml
+  when: ansible_os_family == "Debian" 


### PR DESCRIPTION
Really, this patch is to keep the NDK role from failing when I include it as a dependency in `meta/main.yaml` in another role which applies both Ubuntu and OSX hosts (the OSX ones don't need the NDK). 
