### PR TITLE
Specify that there's no dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,3 +12,5 @@ galaxy_info:
   categories:
   - development
   - system
+  
+dependencies: []


### PR DESCRIPTION
I did it wrong when I PR'd the change to remove the SDK dependency, and now it breaks when I try to ansible-galaxy install the role. Sorry about that.
