### PR TITLE
Added support for NDK 12b

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,9 +2,6 @@
 # defaults file for android-sdk
 
 android_ndk_version: "10e"
-# md5sums come from http://developer.android.com/ndk/downloads/index.html
-android_ndk_md5sum_32bit: "c3edd3273029da1cbd2f62c48249e978"
-ansible_ndk_md5sum_64bit: "19af543b068bdb7f27787c2bc69aba7f"
 android_ndk_install_location: /opt/android/ndk
 
 android_ndk_dependency_packages:

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -10,4 +10,4 @@
 
 - name: Install build dependencies
   apt: pkg={{ item }} state=latest update_cache=yes
-  with_items: android_ndk_dependency_packages
+  with_items: "{{android_ndk_dependency_packages}}"

--- a/tasks/ndktools.yml
+++ b/tasks/ndktools.yml
@@ -1,48 +1,45 @@
 ---
 - name: See if we already have the NDK
   # Check for a file that's created at the end of successful install
-  stat: path="/etc/profile.d/Z99-android-ndk.sh"  
+  stat: path="{{android_ndk_install_location}}/android-ndk-r{{android_ndk_version}}"
   register: ndk_installed_PATH
+
+- debug: var=ndk_installed_PATH
 
 - name: Ensure Android NDK tools directory exists
   file: path={{ android_ndk_install_location }} state=directory
 
 - name: Download Android NDK tools, x86_64
   get_url: 
-    url="http://dl.google.com/android/ndk/android-ndk-r{{ android_ndk_version }}-linux-x86_64.bin" 
-    dest="{{ android_ndk_install_location }}/ndk.bin"
-    #checksum="md5:{{ android_ndk_md5sum_64bit }}"
+    url="http://dl.google.com/android/repository/android-ndk-r{{ android_ndk_version }}-linux-x86_64.zip" 
+    dest="{{ android_ndk_install_location }}/ndk-{{android_ndk_version}}.zip"
   when: ansible_userspace_bits == "64" and 
         ndk_installed_PATH.stat.exists == False
 
 - name: Download Android NDK tools, x86
   get_url: 
-    url="http://dl.google.com/android/ndk/android-ndk-r{{ android_ndk_version }}-linux-x86.bin" 
-    dest="{{ android_ndk_install_location }}/ndk.bin"
-    #checksum="md5:{{ android_ndk_md5sum_32bit }}"
+    url="http://dl.google.com/android/repository/android-ndk-r{{ android_ndk_version }}-linux-x86.zip" 
+    dest="{{ android_ndk_install_location }}/ndk-{{android_ndk_version}}.zip"
   when: ansible_userspace_bits == "32" and 
         ndk_installed_PATH.stat.exists == False
 
-- name: Change ndk.bin permissions
-  file: path="{{ android_ndk_install_location }}/ndk.bin" mode="0755"
-  when: ndk_installed_PATH.stat.exists == False
-
-- name: Execute NDK installer
-  command: "{{ android_ndk_install_location }}/ndk.bin"
-  args:
-      chdir: "{{ android_ndk_install_location }}"
-      # Test whether installation has succeeded before on this host
-      creates: /etc/profile.d/Z99-android-ndk.sh
+- name: Unarchive the NDK
+  unarchive: 
+    src: "{{ android_ndk_install_location }}/ndk-{{ android_ndk_version }}.zip"
+    dest: "{{ android_ndk_install_location }}"
+    # Test whether installation has succeeded before on this host
+    remote_src: True
+    creates: "{{android_ndk_install_location}}/android-ndk-r{{android_ndk_version}}"
   when: ndk_installed_PATH.stat.exists == False
 
 - name: Remove alias
   file: path="{{ android_ndk_install_location }}/android-ndk-linux" state="absent"
 
 - name: Create alias for NDK
-  file: src="{{ android_ndk_install_location }}/android-ndk-r{{ android_ndk_version }}" dest="{{ android_ndk_install_location }}/android-ndk-linux" state=link
+  file: src="{{ android_ndk_install_location }}/android-ndk-r{{ android_ndk_version }}" dest="{{ android_ndk_install_location }}/android-ndk-linux" state=link force=yes
 
 - name: Remove downloaded file
-  file: path={{ android_ndk_install_location }}/ndk.bin state=absent
+  file: path="{{ android_ndk_install_location }}/ndk-r{{android_ndk_version}}.zip" state=absent
 
 - name: Set PATH in /etc/profile.d
   template: src=android-ndk.sh.j2 dest=/etc/profile.d/Z99-android-ndk.sh


### PR DESCRIPTION
Role updated:
* NDK is already available in ZIP files (including older versions)
* Installation criteria changed to check for the folders
* Added support for multiple NDK installations
  NOTE: Last installed will be the default one (symbolic link is replaced)

Tested with 10e and 12b on a single machine.